### PR TITLE
add roles to the response json

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -43,7 +43,7 @@ const handleLogin = async (req, res) => {
             JSON.stringify(usersDB.users)
         );
         res.cookie('jwt', refreshToken, { httpOnly: true, sameSite: 'None', secure: true, maxAge: 24 * 60 * 60 * 1000 });
-        res.json({ accessToken });
+        res.json({ roles, accessToken });
     } else {
         res.sendStatus(401);
     }

--- a/controllers/refreshTokenController.js
+++ b/controllers/refreshTokenController.js
@@ -29,7 +29,7 @@ const handleRefreshToken = (req, res) => {
                 process.env.ACCESS_TOKEN_SECRET,
                 { expiresIn: '30s' }
             );
-            res.json({ accessToken })
+            res.json({ users, accessToken })
         }
     );
 }


### PR DESCRIPTION
On the corresponding front-end project, roles is expected as well in response to user's login, otherwise it will always redirect to the unauthorized page (the Missing component). To be more precise, the line that says: `const roles = response?.data?.roles;` in the Login component of this project: "https://github.com/gitdagray/react_login_hooks/blob/main/src/components/Login.js". Thank you.